### PR TITLE
fix: limit AMT credit usage to (regular_tax - amt) per IRS Form 8801

### DIFF
--- a/calculators/amt_calculator.py
+++ b/calculators/amt_calculator.py
@@ -161,8 +161,11 @@ def calculate_federal_amt(
         amt_credit_used = 0.0
     else:
         # Paying regular tax: use existing credits, don't generate new ones
+        # Per IRS Form 8801, AMT credit can only reduce regular tax DOWN TO
+        # the tentative minimum tax (AMT), not below it.
         amt_credit_generated = 0.0
-        amt_credit_used = min(existing_amt_credit, regular_tax)
+        max_credit_usable = regular_tax - amt_tax
+        amt_credit_used = min(existing_amt_credit, max_credit_usable)
         tax_owed = regular_tax - amt_credit_used
 
     # Calculate the effective additional tax due to AMT adjustments
@@ -234,8 +237,11 @@ def calculate_amt_for_annual_tax(
         amt_credit_used = 0.0
     else:
         # Paying regular tax: use existing credits, don't generate new ones
+        # Per IRS Form 8801, AMT credit can only reduce regular tax DOWN TO
+        # the tentative minimum tax (AMT), not below it.
         amt_credit_generated = 0.0
-        amt_credit_used = min(existing_amt_credit, regular_tax_before_credits)
+        max_credit_usable = regular_tax_before_credits - amt_tax
+        amt_credit_used = min(existing_amt_credit, max_credit_usable)
         tax_owed = regular_tax_before_credits - amt_credit_used
 
     # Calculate AMT credit carryforward

--- a/input_data/demo_profile.json
+++ b/input_data/demo_profile.json
@@ -113,7 +113,8 @@
     "estimated_taxes": {
       "quarterly_payments": 0,
       "regular_income_withholding_rate": 0.35,
-      "supplemental_income_withholding_rate": 0.33
+      "supplemental_income_withholding_rate": 0.33,
+      "income_tax_withholding_rate": 0.31
     }
   },
   "financial_position": {

--- a/tests/test_amt_credit_bug.py
+++ b/tests/test_amt_credit_bug.py
@@ -136,5 +136,53 @@ class TestAMTCreditBug(unittest.TestCase):
         # Can use existing credits to reduce regular tax
 
 
+    def test_amt_credit_usage_limited_to_regular_minus_amt(self):
+        """
+        Test that AMT credit usage is limited to (regular_tax - amt).
+
+        Per IRS Form 8801, AMT credits can only reduce regular tax DOWN TO
+        the tentative minimum tax (AMT), not below it.
+
+        Example:
+        - Regular tax: $50,000
+        - AMT (tentative minimum tax): $30,000
+        - Existing AMT credits: $100,000
+        - Max credit usable: $50,000 - $30,000 = $20,000
+        - Tax owed: $50,000 - $20,000 = $30,000 (equals AMT floor)
+
+        BUG (old behavior): Used min($100k, $50k) = $50k, paying $0 federal
+        FIX (correct): Use min($100k, $20k) = $20k, paying $30k (the AMT floor)
+        """
+        result = calculate_amt_for_annual_tax(
+            agi=175000.0,  # Moderate W2 income
+            iso_bargain_element=0.0,  # No ISO this year (regular year)
+            filing_status='single',
+            existing_amt_credit=100000.0,  # Large credit from prior AMT years
+            regular_tax_before_credits=50000.0  # Regular tax on this income
+        )
+
+        print(f"\nAMT Credit Usage Limit Test:")
+        print(f"  Regular tax: $50,000")
+        print(f"  AMT (tentative min): ${result['amt']:,.2f}")
+        print(f"  Existing credits: $100,000")
+        print(f"  Max usable: regular - amt = ${50000 - result['amt']:,.2f}")
+        print(f"  Credits used: ${result['amt_credit_used']:,.2f}")
+        print(f"  Tax owed: ${result['tax_owed']:,.2f}")
+
+        # The key assertion: credits used should be limited to (regular - amt)
+        max_usable = 50000.0 - result['amt']
+        self.assertLessEqual(result['amt_credit_used'], max_usable,
+                            f"AMT credit usage must be <= (regular_tax - amt) = ${max_usable:,.2f}")
+
+        # Tax owed should never go below the AMT floor
+        self.assertGreaterEqual(result['tax_owed'], result['amt'],
+                               f"Tax owed (${result['tax_owed']:,.2f}) must be >= AMT floor (${result['amt']:,.2f})")
+
+        # Verify the exact credit used matches our limit
+        expected_credit_used = min(100000.0, max_usable)
+        self.assertAlmostEqual(result['amt_credit_used'], expected_credit_used, places=2,
+                              msg=f"Credits used should be exactly min(available, max_usable)")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
AMT credits can only reduce regular tax DOWN TO the tentative minimum tax (AMT), not below it. The previous implementation incorrectly used min(existing_credit, regular_tax) which allowed excessive credit usage.

Example of the bug:
- Regular tax: $50,000
- AMT (tentative min): $22,594
- Existing credits: $100,000
- OLD (bug): Used min($100k, $50k) = $50k, paying $0 federal
- NEW (fix): Use min($100k, $27,406) = $27,406, paying $22,594

Reference: IRS Form 8801 instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)